### PR TITLE
Add verify.yml for Molecule checks

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,6 +15,7 @@ provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+    verify: verify.yml
 scenario:
   test_sequence:
     - lint

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,32 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+  tasks:
+    - name: Determine phpMyAdmin config file path
+      set_fact:
+        phpmyadmin_config_file: >-
+          {{ phpmyadmin_config_file | default(
+            (ansible_os_family == 'RedHat') | ternary(
+              '/etc/phpMyAdmin/config.inc.php',
+              '/etc/phpmyadmin/config.inc.php')) }}
+
+    - name: Ensure phpMyAdmin config file exists
+      stat:
+        path: "{{ phpmyadmin_config_file }}"
+      register: pma_config
+
+    - name: Assert phpMyAdmin config file present
+      assert:
+        that:
+          - pma_config.stat.exists
+
+    - name: Read phpMyAdmin config file
+      slurp:
+        src: "{{ phpmyadmin_config_file }}"
+      register: pma_conf_content
+
+    - name: Assert phpMyAdmin config contains MySQL host
+      assert:
+        that:
+          - "'{{ phpmyadmin_mysql_host }}' in (pma_conf_content.content | b64decode)"


### PR DESCRIPTION
## Summary
- add Molecule verify playbook to assert config file
- run verify.yml in scenario

## Testing
- `yamllint .`
- `ansible-lint` *(fails: parser errors and FQCN warnings)*
- `molecule syntax` *(fails: driver docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841207a9ae083269e2f26ced63e5bc7