### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These variables define the connection method and hostname phpMyAdmin will use to
     phpmyadmin_mysql_user: root
     phpmyadmin_mysql_password: "{{ mysql_root_password }}"
 
-The username and password with which phpMyAdmin will attempt to log into the MySQL server. The `mysql_root_password` should be set as part of the `geerlingguy.mysql` role, but you can change the user and password to another account entirely, and you most defintely *should*, especially if you're connecting to a non-development database server!
+The username and password with which phpMyAdmin will attempt to log into the MySQL server. The `mysql_root_password` should be set as part of the `geerlingguy.mysql` role, but you can change the user and password to another account entirely, and you most definitely *should*, especially if you're connecting to a non-development database server!
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- fix a typo in the README

## Testing
- `yamllint .`
- `molecule test` *(fails: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_6841207568608326894a809b17aecbc6