### PR TITLE
Fix README EPEL requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ phpMyAdmin is a simple interface for interacting with MySQL databases via a web 
 
 ## Requirements
 
-**RedHat/CentOS**: Requires the EPEL repository on RedHat/CentOS 6.x hosts. You can install the EPEL repository using the `geerlingguy.repo-epel` role.
+**RedHat/CentOS**: Requires the EPEL repository on RHEL/CentOS hosts. You can install the EPEL repository using the `geerlingguy.repo-epel` role.
 
 **Debian/Ubuntu**: None.
 


### PR DESCRIPTION
## Summary
- clarify EPEL requirement for RHEL/CentOS in README

## Testing
- `molecule test` *(fails: Failed to find driver docker)*

------
https://chatgpt.com/codex/tasks/task_e_68407f69766c832683a1934d26f0d10b